### PR TITLE
Don't prepend the Staging entry item in the review apps list

### DIFF
--- a/AMI/Home/ReviewAppView.swift
+++ b/AMI/Home/ReviewAppView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ReviewAppView: View {
     @EnvironmentObject var webService: WebService
-    @State private var reviewApps = [ReviewApp(url: Config.shared.BASE_URL, title: "Staging", number: 0, description: nil)]
+    @State private var reviewApps: [ReviewApp] = []
     
     var body: some View {
         NavigationView {


### PR DESCRIPTION
This is following the merge of
https://github.com/numerique-gouv/ami-notifications-api/pull/426