### PR TITLE
First go back in the WebView's history if possible, before going back through the native views

### DIFF
--- a/AMI/Home/HomeView.swift
+++ b/AMI/Home/HomeView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import WebKit
 
 struct HomeView: View {
+    @Environment(\.dismiss) var dismiss
     @State var isExternalProcess = false
     @State var webViewRef: WKWebView?
     @State var isLoading = false
@@ -27,6 +28,33 @@ struct HomeView: View {
                     .tint(.blue)
             }
             WebView(initialURL: Config.shared.BASE_URL, isExternalProcess: $isExternalProcess, webViewRef: $webViewRef, isLoading: $isLoading, loadingProgress: $loadingProgress)
+            .navigationBarBackButtonHidden(true)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: handleBackAction) {
+                        HStack {
+                            Image(systemName: "chevron.left")
+                            Text("Retour")
+                        }
+                    }
+                }
+            }
+            .gesture(
+                DragGesture()
+                    .onEnded { gesture in
+                        if gesture.translation.width > 50 {
+                            handleBackAction()
+                        }
+                    }
+            )
+        }
+    }
+
+    private func handleBackAction() {
+        if let webView = webViewRef, webView.canGoBack {
+            webView.goBack()
+        } else {
+            dismiss()
         }
     }
 }


### PR DESCRIPTION
This also takes the swipe from left gesture familiar to iPhone users.

Fixes [#472](https://github.com/numerique-gouv/ami-notifications-api/issues/472)