### PR TITLE
Display an information banner when the network connectivity is lost (#471)

### DIFF
--- a/AMI/AMIApp.swift
+++ b/AMI/AMIApp.swift
@@ -12,6 +12,8 @@ struct AMIApp: App {
 
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     @StateObject private var bannerManager = InformationBannerManager.shared
+    @StateObject private var networkMonitor = NetworkMonitor.shared
+    @State private var offlineBannerId: UUID?
 
     var body: some Scene {
         WindowGroup {
@@ -30,6 +32,23 @@ struct AMIApp: App {
                 }
             }
             .animation(.easeInOut(duration: 0.3), value: bannerManager.banners.count)
+            .environmentObject(networkMonitor)
+            .onChange(of: networkMonitor.isConnected) { isConnected in
+                print("Main App: received a network status change, isConnected=\(isConnected)") 
+                if isConnected {
+                    if let id = offlineBannerId {
+                        bannerManager.dismissBanner(id: id)
+                        offlineBannerId = nil
+                    }
+                } else {
+                    offlineBannerId = bannerManager.showBanner(
+                        .warning,
+                        title: "Vous êtes hors ligne",
+                        content: "L'accès à certaines fonctionnalités est limité.",
+                        hasCloseIcon: false
+                    )
+                }
+            }
         }
     }
 }

--- a/AMI/Components/InformationBanner.swift
+++ b/AMI/Components/InformationBanner.swift
@@ -18,6 +18,7 @@ class InformationBannerManager: ObservableObject {
 
     @Published var banners: [BannerData] = []
 
+    @discardableResult
     func showBanner(
         _ informationType: InformationType,
         title: String,
@@ -27,7 +28,7 @@ class InformationBannerManager: ObservableObject {
         hasCloseIcon: Bool = true,
         icon: String? = nil,
         onClose: (() -> Void)? = nil
-    ) {
+    ) -> UUID {
         let id = UUID()
         let banner = BannerData(
             id: id,
@@ -41,6 +42,7 @@ class InformationBannerManager: ObservableObject {
             onClose: onClose
         )
         banners.append(banner)
+        return id
     }
 
     func dismissBanner(id: UUID) {

--- a/AMI/Services/NetworkMonitor.swift
+++ b/AMI/Services/NetworkMonitor.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Network
+
+class NetworkMonitor: ObservableObject {
+    static let shared = NetworkMonitor()
+
+    @Published private(set) var isConnected = true
+
+    private let monitor = NWPathMonitor()
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            print("NetworkMonitor: network status changed to \(path.status)") 
+            DispatchQueue.main.async {
+                self?.isConnected = path.status == .satisfied
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "NetworkMonitor"))
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/numerique-gouv/ami-notifications-api/issues/471