### PR TITLE
47 enlever le bouton back natif sur la version ios staging

### DIFF
--- a/AMI/Home/HomeView.swift
+++ b/AMI/Home/HomeView.swift
@@ -33,16 +33,16 @@ struct HomeView: View {
                     loadingProgress: $loadingProgress,
                     showNoEmailClientAlert: $showNoEmailClientAlert)
             .navigationBarBackButtonHidden(true)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: handleBackAction) {
-                        HStack {
-                            Image(systemName: "chevron.left")
-                            Text("Retour")
-                        }
-                    }
-                }
-            }
+//            .toolbar {
+//                ToolbarItem(placement: .navigationBarLeading) {
+//                    Button(action: handleBackAction) {
+//                        HStack {
+//                            Image(systemName: "chevron.left")
+//                            Text("Retour")
+//                        }
+//                    }
+//                }
+//            }
             .gesture(
                 DragGesture()
                     .onEnded { gesture in


### PR DESCRIPTION
Fix #47 

J'ai simplement commenté le bouton Retour natif.

<img width="300" height="650" alt="simulator_screenshot_D8F2C065-C8E0-44C9-9B38-F9B87F8BAA1D" src="https://github.com/user-attachments/assets/599afee4-e576-4949-92c3-8a0a5f2351a0" />
