### PR TITLE
Fix the review app selection change

### DIFF
--- a/AMI/Sources/Components/Tile.swift
+++ b/AMI/Sources/Components/Tile.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct Tile: View {
     @State var title: String
     @State var content: String
-    @State var action: () -> Void
 
     var body: some View {
         HStack {
@@ -32,9 +31,6 @@ struct Tile: View {
             .border(width: 8, edges: [.bottom], color: Asset.Colors.blueFranceSun113.swiftUIColor)
         }
         .padding(16)
-        .simultaneousGesture(TapGesture().onEnded {
-            action()
-        })
     }
 }
 
@@ -61,5 +57,5 @@ struct EdgeBorder: Shape {
 }
 
 #Preview {
-    Tile(title: "PR239", content: "build two apps per platforms") {}
+    Tile(title: "PR239", content: "build two apps per platforms")
 }

--- a/AMI/Sources/Components/WebView.swift
+++ b/AMI/Sources/Components/WebView.swift
@@ -16,11 +16,16 @@ struct WebView: UIViewRepresentable {
     @Binding var loadingProgress: Double
     @Binding var isOnContactPage: Bool
     @Binding var shouldPresentSettings: Bool
-    
+
     func makeUIView(context: Context) -> some UIView {
         let webView = WebViewManager.shared.webView
         let contentController = webView.configuration.userContentController
 
+        // Make sure to cleanup the potential existing content controllers before trying to add them again.
+        // WebView is a singleton, so it's reused for example when going back to the review app screen to
+        // select another review app.
+        contentController.removeAllScriptMessageHandlers()
+        contentController.removeAllUserScripts()
         NativeEvents.attach(contentController, context.coordinator)
 
         #if DEBUG

--- a/AMI/Sources/Home/ReviewAppView.swift
+++ b/AMI/Sources/Home/ReviewAppView.swift
@@ -20,6 +20,7 @@ struct ReviewAppView: View {
                     if let reviewAppUrl = URL(string: reviewApp.url) {
                         Button {
                             Config.shared.BASE_URL = reviewAppUrl
+                            print("ReviewAppView: switching to BASE_URL=\(Config.shared.BASE_URL)")
                             navigate = true
                         } label: {
                             Tile(title: reviewApp.title, content: reviewApp.description ?? "")

--- a/AMI/Sources/Home/ReviewAppView.swift
+++ b/AMI/Sources/Home/ReviewAppView.swift
@@ -10,22 +10,27 @@ import SwiftUI
 struct ReviewAppView: View {
     @EnvironmentObject var webService: WebService
     @State private var reviewApps: [ReviewApp] = []
+    @State private var navigate: Bool = false
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 Text("Choix de la review")
                 ForEach(reviewApps, id: \.id) { reviewApp in
                     if let reviewAppUrl = URL(string: reviewApp.url) {
-                        NavigationLink(destination: HomeView()) {
-                            Tile(title: reviewApp.title, content: reviewApp.description ?? "") {
-                                Config.shared.BASE_URL = reviewAppUrl
-                            }
+                        Button {
+                            Config.shared.BASE_URL = reviewAppUrl
+                            navigate = true
+                        } label: {
+                            Tile(title: reviewApp.title, content: reviewApp.description ?? "")
                         }
                     }
                 }
             }
             .padding(.top, 1)
+            .navigationDestination(isPresented: $navigate) {
+                HomeView()
+            }
             .onAppear {
                 Task {
                     try await webService.getReviewApps()

--- a/AMI/Sources/Home/ReviewAppView.swift
+++ b/AMI/Sources/Home/ReviewAppView.swift
@@ -35,7 +35,7 @@ struct ReviewAppView: View {
             .onAppear {
                 Task {
                     try await webService.getReviewApps()
-                    reviewApps.append(contentsOf: webService.reviewApps)
+                    reviewApps = webService.reviewApps
                 }
             }
         }


### PR DESCRIPTION
Fixes #50, based on #51

Il y a deux autres possibilités que j'ai envisagées :
1. supprimer le NativeBridge (et ConsoleLog) existant avant d'en recréer un
2. supprimer `WebViewManager.shared.webView` avant d'en recréer une

Cette option m'a paru la plus simple et robuste, mais ça nous fait "perdre" le singleton, qu'en pensez-vous ?

Edit du mercredi 25 mars : en travaillant sur le ticket #53, j'ai découvert un autre use case où on va tenter d'ajouter des content controllers sur une webview déjà existante. Pour répondre à ces deux cas, probable que la solution 1 soit finalement la plus adaptée. J'ai donc changé le code.