### PR TITLE
Initialize views HomeView and ReviewAppView with view models

### DIFF
--- a/AMI/Sources/AMIApp.swift
+++ b/AMI/Sources/AMIApp.swift
@@ -19,9 +19,9 @@ struct AMIApp: App {
 
     #if IS_AMI_STAGING
         let reviewAppViewModel: ReviewAppView.ViewModel
-    #else
-        let homeViewModel = HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager)
     #endif
+
+    private static let homeViewModel = HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager)
 
     init() {
         #if IS_AMI_STAGING
@@ -35,13 +35,15 @@ struct AMIApp: App {
         ZStack(alignment: .top) {
             #if IS_AMI_STAGING // && FALSE
                 if openedFromNotification {
-                    HomeView(viewModel: HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager))
+                    // TODO: should initialize home view model with review app backend url.
+                    // Can I get it via the received notification?
+                    HomeView(viewModel: Self.homeViewModel)
                 } else {
                     ReviewAppView(viewModel: reviewAppViewModel)
                         .environmentObject(WebService())
                 }
             #else
-                HomeView(viewModel: homeViewModel)
+                HomeView(viewModel: Self.homeViewModel)
             #endif
 
             VStack(spacing: 0) {

--- a/AMI/Sources/AMIApp.swift
+++ b/AMI/Sources/AMIApp.swift
@@ -19,9 +19,9 @@ struct AMIApp: App {
 
     #if IS_AMI_STAGING
         let reviewAppViewModel: ReviewAppView.ViewModel
-    #else
-        let homeViewModel = HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager)
     #endif
+
+    private static let homeViewModel = HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager)
 
     init() {
         #if IS_AMI_STAGING
@@ -35,7 +35,9 @@ struct AMIApp: App {
         ZStack(alignment: .top) {
             #if IS_AMI_STAGING // && FALSE
                 if openedFromNotification {
-                    HomeView(viewModel: HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager))
+                    // TODO: should initialize home view model with review app backend url.
+                    // Can I get it via the received notification?
+                    HomeView(viewModel: Self.homeViewModel)
                 } else {
                     ReviewAppView(viewModel: reviewAppViewModel)
                         .environmentObject(WebService())

--- a/AMI/Sources/AMIApp.swift
+++ b/AMI/Sources/AMIApp.swift
@@ -15,17 +15,19 @@ struct AMIApp: App {
     @State private var offlineBannerId: UUID?
     @State private var openedFromNotification = false
 
-    let notificationManager = NotificationManager()
+    private static let notificationManager = NotificationManager()
 
     #if IS_AMI_STAGING
         let reviewAppViewModel: ReviewAppView.ViewModel
+    #else
+        let homeViewModel = HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager)
     #endif
 
     init() {
         #if IS_AMI_STAGING
-            reviewAppViewModel = ReviewAppView.ViewModel(notificationManager: notificationManager)
+            reviewAppViewModel = ReviewAppView.ViewModel(notificationManager: Self.notificationManager)
         #endif
-        delegate.notificationManager = notificationManager
+        delegate.notificationManager = Self.notificationManager
     }
 
     @ViewBuilder
@@ -33,13 +35,13 @@ struct AMIApp: App {
         ZStack(alignment: .top) {
             #if IS_AMI_STAGING // && FALSE
                 if openedFromNotification {
-                    HomeView()
+                    HomeView(viewModel: HomeView.ViewModel(rootUrl: Config.shared.BASE_URL, notificationManager: Self.notificationManager))
                 } else {
-                    ReviewAppView()
-					    .environmentObject(WebService())
-            }
+                    ReviewAppView(viewModel: reviewAppViewModel)
+                        .environmentObject(WebService())
+                }
             #else
-                HomeView(initialUrl: Config.shared.BASE_URL)
+                HomeView(viewModel: homeViewModel)
             #endif
 
             VStack(spacing: 0) {


### PR DESCRIPTION
Fix #56 

Avant le refactor, les views `HomeView` et `ReviewAppView` ne nécessitaient pas de view models pour être initialisées.

Ces view models sont maintenant nécessaires et sont passés en paramètre aux views.