### PR TITLE
navigate to promoted page magopian

### DIFF
--- a/AMI/Sources/Components/WebView/WebView-ViewModel.swift
+++ b/AMI/Sources/Components/WebView/WebView-ViewModel.swift
@@ -153,6 +153,10 @@ extension SwiftUIWebView {
         func goBack() {
             webView?.goBack()
         }
+
+        func navigate(to url: URL) {
+            webView?.load(URLRequest(url: url))
+        }
     }
 }
 

--- a/AMI/Sources/Presentation/Home/HomeView-UserScripts.swift
+++ b/AMI/Sources/Presentation/Home/HomeView-UserScripts.swift
@@ -23,12 +23,12 @@ class HomeUserScripts {
         case userLoggedIn = "user_logged_in"
         case notificationPermissionRequested = "notification_permission_requested"
         case notificationPermissionRemoved = "notification_permission_removed"
-        case navigateTo = "navigateTo"
+        case navigateTo
     }
 
     // notificationManager: used to handle notification registration once user is logged.
     let notificationManager: NotificationManager
-    var onNavigate: ((NativeRoute) -> Void)?
+    var onNavigate: ((Any?) -> Void)?
     var scripts: [UserScript]
 
     required init(notificationManager: NotificationManager) {
@@ -175,9 +175,7 @@ extension HomeUserScripts: WebViewUserScriptsProtocol {
             case .notificationPermissionRemoved:
                 notificationManager.openSettings()
             case .navigateTo:
-                if let url = data as? String, let route = findNativeRoute(for: url) {
-                    onNavigate?(route)
-                }
+                onNavigate?(data)
             default:
                 break
             }

--- a/AMI/Sources/Presentation/Home/HomeView-UserScripts.swift
+++ b/AMI/Sources/Presentation/Home/HomeView-UserScripts.swift
@@ -15,6 +15,7 @@ class HomeUserScripts {
     enum Script: String {
         case nativeBridge = "NativeBridge"
         case consoleLog
+        case nativeURLs
     }
 
     // Enumerate existing events
@@ -22,10 +23,12 @@ class HomeUserScripts {
         case userLoggedIn = "user_logged_in"
         case notificationPermissionRequested = "notification_permission_requested"
         case notificationPermissionRemoved = "notification_permission_removed"
+        case navigateTo = "navigateTo"
     }
 
     // notificationManager: used to handle notification registration once user is logged.
     let notificationManager: NotificationManager
+    var onNavigate: ((NativeRoute) -> Void)?
     var scripts: [UserScript]
 
     required init(notificationManager: NotificationManager) {
@@ -38,6 +41,10 @@ class HomeUserScripts {
             UserScript(name: Script.consoleLog.rawValue,
                        script: WKUserScript(source: Self.consoleLogScript,
                                             injectionTime: .atDocumentStart,
+                                            forMainFrameOnly: false)),
+            UserScript(name: Script.nativeURLs.rawValue,
+                       script: WKUserScript(source: Self.nativeURLsScript,
+                                            injectionTime: .atDocumentEnd,
                                             forMainFrameOnly: false)),
         ]
     }
@@ -54,6 +61,14 @@ class HomeUserScripts {
     };
     console.log('NativeBridge initialized');
     """
+
+    // This sets window.NativeURLs so the web frontend knows which URLs are handled natively
+    private static let nativeURLsScript: String = {
+        let urls = Array(nativeRoutes.keys)
+        let data = (try? JSONSerialization.data(withJSONObject: urls)) ?? Data("[]".utf8)
+        let json = String(data: data, encoding: .utf8)! // safe: JSONSerialization always produces valid UTF-8
+        return "window.NativeURLs = \(json);"
+    }()
 
     // JavaScript to capture console logs
     private static let consoleLogScript = """
@@ -117,8 +132,7 @@ extension HomeUserScripts: WebViewUserScriptsProtocol {
             printLog(message)
         case .nativeBridge:
             processMessage(message, for: viewModel)
-        case .none:
-            // Ignore unknown script message names
+        case .nativeURLs, .none:
             break
         }
     }
@@ -160,6 +174,10 @@ extension HomeUserScripts: WebViewUserScriptsProtocol {
                 notificationManager.requestPermission()
             case .notificationPermissionRemoved:
                 notificationManager.openSettings()
+            case .navigateTo:
+                if let url = data as? String, let route = findNativeRoute(for: url) {
+                    onNavigate?(route)
+                }
             default:
                 break
             }

--- a/AMI/Sources/Presentation/Home/HomeView-ViewModel.swift
+++ b/AMI/Sources/Presentation/Home/HomeView-ViewModel.swift
@@ -21,20 +21,25 @@ extension HomeView {
 
         @Sendable
         private func handleUrlChange(webViewViewModel: SwiftUIWebView.ViewModel, url: URL?) {
-            showSettings = url?.absoluteString.hasSuffix("/#/settings") ?? false
-            isOnContactPage = url?.absoluteString.hasSuffix("/#/contact") ?? false
-            isExternalProcess = !(url?.absoluteString.hasPrefix(webViewViewModel.rootUrl.absoluteString) ?? true)
+            let urlString = url?.absoluteString ?? ""
+            isOnContactPage = urlString.hasSuffix("/#/contact") ?? false
+            isExternalProcess = !urlString.hasPrefix(webViewViewModel.rootUrl.absoluteString)
+
+            if let route = findNativeRoute(for: urlString) {
+                Task { @MainActor in
+                    self.navigate(to: route)
+                }
+            }
 
             print("[HomeView-ViewModel]: URL Change Action \(url?.debugDescription ?? "<nil>")\n\tsettings: \(showSettings) - contact: \(isOnContactPage) - external: \(isExternalProcess)")
+        }
 
-            Task { @MainActor in
-                if self.showSettings,
-                   self.webViewViewModel.webView?.canGoBack ?? false {
-                    // As new page should not be handled by webview, reset webView last step navigation (to clean history).
-                    self.webViewViewModel.webView?.goBack()
-                    // Force `showSettings` to true because it is reset to false by the `goBack` command.
-                    self.showSettings = true
-                }
+        @MainActor
+        func navigate(to route: NativeRoute) {
+            print("[HomeView-ViewModel]: Promoted page detected, navigating app to \(route)")
+            switch route {
+            case .settings:
+                showSettings = true
             }
         }
 
@@ -45,9 +50,10 @@ extension HomeView {
 
         init(rootUrl: URL, notificationManager: NotificationManager) {
             // Assign first to local variable to be able to use it to instantiate `settingsViewViewModel` without referencing `self`.
+            let homeUserScripts = HomeUserScripts(notificationManager: notificationManager)
             let webViewViewModel = SwiftUIWebView.ViewModel(rootUrl: rootUrl,
                                                             delegate: HomeViewDelegate(),
-                                                            userScripts: HomeUserScripts(notificationManager: notificationManager))
+                                                            userScripts: homeUserScripts)
             self.webViewViewModel = webViewViewModel
             settingsViewViewModel = SettingsView.ViewModel(notificationManager: notificationManager, notificationsSettingDidChangeAction: { newValue in
                 print("[HomeView-ViewModel]: notificationsSettingDidChangeAction")
@@ -60,12 +66,17 @@ extension HomeView {
             // Init `urlChangeAction` property after fully initialized `self` because closure is referencing `self`.
             // No clean way to pass this closure in the `SwiftUIWebView.ViewModel.init` call.
             webViewViewModel.urlChangeAction = handleUrlChange
+            homeUserScripts.onNavigate = { [weak self] route in
+                Task { @MainActor in
+                    self?.navigate(to: route)
+                }
+            }
         }
     }
 }
 
 class HomeViewDelegate: WebViewDelegate {
-    func navigationWillStart(navigationAction: WKNavigationAction) {
+    func navigationWillStart(navigationAction _: WKNavigationAction) {
         print("[WebViewDelegate navigationWillStart]")
     }
 

--- a/AMI/Sources/Presentation/Home/HomeView-ViewModel.swift
+++ b/AMI/Sources/Presentation/Home/HomeView-ViewModel.swift
@@ -27,20 +27,14 @@ extension HomeView {
 
             if let route = findNativeRoute(for: urlString) {
                 Task { @MainActor in
-                    self.navigate(to: route)
+                    switch route {
+                    case .settings:
+                        self.showSettings = true
+                    }
                 }
             }
 
             print("[HomeView-ViewModel]: URL Change Action \(url?.debugDescription ?? "<nil>")\n\tsettings: \(showSettings) - contact: \(isOnContactPage) - external: \(isExternalProcess)")
-        }
-
-        @MainActor
-        func navigate(to route: NativeRoute) {
-            print("[HomeView-ViewModel]: Promoted page detected, navigating app to \(route)")
-            switch route {
-            case .settings:
-                showSettings = true
-            }
         }
 
         func shareLogs() async {
@@ -66,11 +60,29 @@ extension HomeView {
             // Init `urlChangeAction` property after fully initialized `self` because closure is referencing `self`.
             // No clean way to pass this closure in the `SwiftUIWebView.ViewModel.init` call.
             webViewViewModel.urlChangeAction = handleUrlChange
-            homeUserScripts.onNavigate = { [weak self] route in
-                Task { @MainActor in
-                    self?.navigate(to: route)
+            homeUserScripts.onNavigate = { [weak self] data in
+                if let url = data as? String {
+                    Task { @MainActor in
+                        self?.handleRoute(routeString: url)
+                    }
                 }
             }
+        }
+    }
+}
+
+extension HomeView.ViewModel: WebRouteManagerProtocol {
+    @MainActor
+    func handleRoute(routeString: String) {
+        if let route = findNativeRoute(for: routeString) {
+            print("[HomeView-ViewModel]: Native route detected, navigating app to \(route)")
+            switch route {
+            case .settings:
+                showSettings = true
+            }
+        } else {
+            guard let url = URL(string: routeString, relativeTo: webViewViewModel.rootUrl) else { return }
+            webViewViewModel.navigate(to: url)
         }
     }
 }

--- a/AMI/Sources/Presentation/Home/NativeRoutes.swift
+++ b/AMI/Sources/Presentation/Home/NativeRoutes.swift
@@ -14,3 +14,7 @@ let nativeRoutes: [String: NativeRoute] = [
 func findNativeRoute(for url: String) -> NativeRoute? {
     nativeRoutes.first { (path, _) in url.contains(path) }?.value
 }
+
+protocol WebRouteManagerProtocol {
+    func handleRoute(routeString: String)
+}

--- a/AMI/Sources/Presentation/Home/NativeRoutes.swift
+++ b/AMI/Sources/Presentation/Home/NativeRoutes.swift
@@ -1,0 +1,16 @@
+//
+//  NativeRoutes.swift
+//  AMI
+//
+
+enum NativeRoute {
+    case settings
+}
+
+let nativeRoutes: [String: NativeRoute] = [
+    "/#/settings": .settings
+]
+
+func findNativeRoute(for url: String) -> NativeRoute? {
+    nativeRoutes.first { (path, _) in url.contains(path) }?.value
+}


### PR DESCRIPTION
Suite aux modifications non sollicitées de @NicolasBuquet dans ma PR #63, je repousse une PR ici pour garder une vision claire des modifications que je propose pour tirer parti de la PR [#570](https://github.com/numerique-gouv/ami-notifications-api/issues/570) sur le backend, pour naviguer vers une page promue en natif.

Cette proposition de modification est en miroir de [celle pour Android](https://github.com/numerique-gouv/ami-app-android/pull/50)