### PR TITLE
109 enregistrer le compte auprès du backend au login et à réception d un token

### DIFF
--- a/AMI/Sources/App/AppDelegate.swift
+++ b/AMI/Sources/App/AppDelegate.swift
@@ -15,7 +15,16 @@ extension Notification.Name {
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     // The notificationManager is set by AMIApp.
-    var notificationManager: NotificationManager?
+    var notificationManager: NotificationManager? {
+        didSet {
+            Task {
+                // If Firebase get an existing Apns token, and NotificationManager doesn't have one, set it into NotificationManager.
+                if let currentApnsToken = try? await Messaging.messaging().token() {
+                    notificationManager?.setApnsToken(currentApnsToken)
+                }
+            }
+        }
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         // Setup application
@@ -53,7 +62,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         // So, don't rely on `messaging:didReceiveRegistrationToken` to register device to our backend.
         Task {
             if let token = try? await Messaging.messaging().token() {
-                notificationManager?.registerDeviceForRemoteNotificationsToBackend(apnsToken: token)
+                // Setting Apns token will trigger a backend registration if all needed data is available.
+                notificationManager?.setApnsToken(token)
             }
         }
     }

--- a/AMI/Sources/Presentation/Home/HomeView-ViewModel.swift
+++ b/AMI/Sources/Presentation/Home/HomeView-ViewModel.swift
@@ -124,6 +124,9 @@ extension HomeView {
             webViewViewModel.urlChangeAction = handleUrlChange
             userScripts.userLoggedInAction = userLoginActions
             userScripts.userLoggedOutAction = userLogoutActions
+
+            // Set NotificationManager base URL to register the device to AMI backend to allow Push Notifications.
+            setNotificationManagerBaseUrl(rootUrl)
         }
 
         private func userLoginActions() {
@@ -188,6 +191,10 @@ extension HomeView {
             Task { @MainActor in
                 isPresentingOnboardingView = true
             }
+        }
+
+        private func setNotificationManagerBaseUrl(_ url: URL) {
+            notificationManager.setBaseUrl(url)
         }
 
         private func setNotificationManagerUserAuthentificationToken(_ token: String) {

--- a/AMI/Sources/Presentation/Onboarding/OnboardingViewModel.swift
+++ b/AMI/Sources/Presentation/Onboarding/OnboardingViewModel.swift
@@ -57,7 +57,7 @@ extension OnboardingView {
 
         private func registerForRemoteNotifications() {
             Task {
-                await notificationManager.registerForRemoteNotifications(baseUrl: applicationRootUrl)
+                await notificationManager.registerForRemoteNotifications()
             }
         }
 

--- a/AMI/Sources/Services/NotificationManager/NotificationManager.swift
+++ b/AMI/Sources/Services/NotificationManager/NotificationManager.swift
@@ -18,14 +18,29 @@ class NotificationManager: NSObject {
     private var baseUrl: URL?
     // userAuthenticationToken will be set after user logged in successfully.
     private var userAuthenticationToken: String?
+    // apnsToken will be set after allowing Push Notifications or Push Notification token renewal.
+    private var apnsToken: String?
 
     override init() {
         super.init()
     }
 
-    func registerForRemoteNotifications(baseUrl: URL) async {
-        self.baseUrl = baseUrl
+    func setBaseUrl(_ url: URL) {
+        baseUrl = url
+        tryToRegisterDeviceForRemoteNotificationsToBackend()
+    }
 
+    func setUserAuthenticationToken(_ token: String?) {
+        userAuthenticationToken = token
+        tryToRegisterDeviceForRemoteNotificationsToBackend()
+    }
+
+    func setApnsToken(_ token: String?) {
+        apnsToken = token
+        tryToRegisterDeviceForRemoteNotificationsToBackend()
+    }
+
+    func registerForRemoteNotifications() async {
         switch await NotificationStatus.notificationsAuthorizationStatus() {
         case .notDetermined:
             await NotificationStatus.requestNotificationsActivation()
@@ -40,9 +55,14 @@ class NotificationManager: NSObject {
         }
     }
 
-    func registerDeviceForRemoteNotificationsToBackend(apnsToken: String) {
+    private func tryToRegisterDeviceForRemoteNotificationsToBackend() {
         guard let baseUrl else {
             AppLog.service.warning("\(AppLog.logHeader(self)) Base url is not defined")
+            return
+        }
+
+        guard let apnsToken else {
+            AppLog.service.warning("\(AppLog.logHeader(self)) ApnsToken is not defined")
             return
         }
 
@@ -57,10 +77,6 @@ class NotificationManager: NSObject {
                                                   apnsToken: apnsToken,
                                                   userAuthenticationToken: userAuthenticationToken)
         }
-    }
-
-    func setUserAuthenticationToken(_ token: String?) {
-        userAuthenticationToken = token
     }
 }
 


### PR DESCRIPTION
Fix #109 

Maintenant, on enregistre auprès du NotificationManager au fur et à mesure de leurs arrivées : 
- la base url (pour avoir l'url du backend)
- le token d'authentification du user loggué
- le token Apns

A chaque mise à jour d'une de ces données, on essaie de faire un register auprès du backend si toutes ces données sont renseignées.